### PR TITLE
feat(grad): on-demand revalidation (?fresh=1)

### DIFF
--- a/src/pages/api/grad/[g].ts
+++ b/src/pages/api/grad/[g].ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { getGradSection, fetchGradTree } from "../../../lib/grad-server";
+import { serverInvalidate } from "../../../lib/server-cache";
 
 export default async function handler(
   req: NextApiRequest,
@@ -19,6 +20,15 @@ export default async function handler(
   }
 
   try {
+    // Owner lever: append ?fresh=1 after editing Drive to drop this
+    // instance's cached trees and rebuild immediately instead of waiting
+    // out the 10-minute TTL. (Per serverless instance, hence the prefix
+    // invalidation — trees are few and cheap to rebuild.)
+    if (req.query.fresh === "1") {
+      serverInvalidate("grad-tree:");
+      serverInvalidate("grad-thumb");
+    }
+
     const tree = await fetchGradTree(g);
     if (!tree) {
       return res.status(404).json({ message: "Not found" });


### PR DESCRIPTION
After editing the hidden section's Drive folder, production kept serving the in-memory-cached tree for up to 10 minutes. This adds an owner lever: hitting `/api/grad/<key>?fresh=1` invalidates the serving instance's cached trees + thumbnail metadata and rebuilds from Drive immediately.

- Prefix invalidation (`grad-tree:` / `grad-thumb`) — covers key casing and both cache families; trees are few and cheap to rebuild.
- Gating unchanged: unknown keys and teaser sections 404 before the lever is reachable.
- Note: serverless caches are per-instance, so `?fresh=1` refreshes the instance that serves the request — in practice one or two hits clears everything, and the 10-min TTL remains the backstop.

Verified locally: `?fresh=1` returns the just-edited Drive state (38→43 files) with `fetchedAt` of now; `/api/grad/cv?fresh=1` still 404s; tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)