### PR TITLE
fix(ui): ensure LinkTree text is visible in light theme

### DIFF
--- a/src/components/NameHref.tsx
+++ b/src/components/NameHref.tsx
@@ -102,7 +102,7 @@ export default function NameHref({ name, dataName, dataHref, variant }: Props) {
               onClick={handleClose}
               sx={{
                 textDecoration: "none",
-                color: "#fff",
+                color: "text.primary",
                 "&:hover": {
                   textDecoration: "underline",
                 },


### PR DESCRIPTION
## Description
This PR fixes a CSS contrast bug in the `Footer` component where the contact links (e.g., LinkTree, phone, email) inside the popover menu were invisible when the light theme was active. 

Closes #94

## Changes Made
* **`src/components/NameHref.tsx`**: Replaced the hardcoded `color: "#fff"` with Material UI's theme-aware `color: "text.primary"` inside the `<MenuItem>` component. This ensures the text automatically switches between dark and light colors based on the active theme.

## Testing
* Verified the component in Storybook by rendering it in both light and dark modes to ensure text legibility.

<details>
<summary><b>Before: with the old color: "#fff"</b></summary>
<img width="892" height="313" alt="image" src="https://github.com/user-attachments/assets/7f2a172d-e4c5-419b-be41-c3f037738490" />

</details>

<br/>

<details>
<summary><b>After: with the new "text.primary"</b></summary>
<img width="892" height="313" alt="image" src="https://github.com/user-attachments/assets/fb04aae1-12c1-4192-9775-972cde279956" />
</details>
